### PR TITLE
Fix copy/paste error in code to retrieve trackers.

### DIFF
--- a/mentor.el
+++ b/mentor.el
@@ -1502,7 +1502,7 @@ Should be equivalent to the ^K command in the ncurses gui."
 
 (defun mentor-download-tracker-name-column (&optional download)
   (let* ((t_urls (mentor-item-property 't_url download))
-         (t_is_enableds (mentor-item-property 't_url download))
+         (t_is_enableds (mentor-item-property 't_is_enabled download))
          (active-trackers
           (cl-mapcar (lambda (url is_enabled) (when is_enabled url))
                      t_urls t_is_enableds))


### PR DESCRIPTION
Without this fix, all trackers are considered active trackers.